### PR TITLE
QA and Frontend-fixes

### DIFF
--- a/files/contaodemo/theme/src/scss/components/_calendar.scss
+++ b/files/contaodemo/theme/src/scss/components/_calendar.scss
@@ -1,8 +1,8 @@
-
 $calendar--switch-mobile: md;
 
 .mod_calendar {
   @extend %table-overflow;
+  overflow: auto visible;
 }
 
 .calendar {
@@ -114,5 +114,3 @@ $calendar--switch-mobile: md;
     text-align: center;
   }
 }
-
-

--- a/files/contaodemo/theme/src/scss/components/basic-contents/_table.scss
+++ b/files/contaodemo/theme/src/scss/components/basic-contents/_table.scss
@@ -46,6 +46,10 @@ th {
 
   @include breakpoint(#{$table--switch-mobile}, max) {
     display: none;
+
+    .mod_calendar & {
+      display: revert;
+    }
   }
 }
 
@@ -54,6 +58,10 @@ td {
 
   @include breakpoint(#{$table--switch-mobile}, max) {
     display: grid;
+
+    .mod_calendar & {
+      display: revert;
+    }
   }
 
   @include breakpoint(#{$table--inline-cell-content}) {
@@ -87,6 +95,10 @@ td {
       font-weight: 600;
 
       content: attr(data-cellheadline) ': ';
+
+      .mod_calendar & {
+        content: none;
+      }
     }
   }
 }

--- a/files/contaodemo/theme/src/scss/layout/_article.scss
+++ b/files/contaodemo/theme/src/scss/layout/_article.scss
@@ -98,7 +98,7 @@
   // header-slider
   &.header-image {
     @include breakpoint(lg, max) {
-      margin-inline: -$s-grid-outer-gutter--large;
+      padding: 0;
     }
 
     #{$parent}__inner {

--- a/files/contaodemo/theme/src/scss/layout/_article.scss
+++ b/files/contaodemo/theme/src/scss/layout/_article.scss
@@ -3,6 +3,7 @@
 
   display: flex;
   justify-content: center;
+  flex-wrap: wrap;
 
   &__inner {
     display: grid;


### PR DESCRIPTION
## Information
These changes can be upstreamed to the 5.2.*-branch as it doesn't touch any files besides ``_table.scss`` (just consider the classname change in the 5.2 branch)

_____

## Fixes
This PR fixes following issues:


### Always consider flex-wrap within mod_article 1ba8421338b01d0fad511a8fd80cc39b087a7709
This can lead to a lot of issues where every content will be shown in the same row. Not every browser (Chrome, Chromium-based, Safari) will break flex on default.
![EventsSocialMedia_Fix](https://github.com/contao/contao-demo/assets/55794780/56883785-f997-46ba-a561-482f17870a84)

### Header-Image-Slider overflowing on mobile devices due to using a negative margin ff7959e5dfb613af2bd75c3c0ec1326f0ec298eb

I removed the margin-inline as it did break on mobile devices, you can see the initial version in this screenshot:
![Slider-Fix](https://github.com/contao/contao-demo/assets/55794780/7e81d403-cc1c-4644-bc98-dab970fd5a2b)

### Fixed events display on mobile devices 77f0fab153c731b05d39e898e04a1f2bceaeb756

The events calendar was broken completely on mobile devices due to the table styles, I added some revert styles to properly show the tables. (Imho, the media-breakpoints need a rework as there is lots of filesize to save)

![EventsCalendar-Fix](https://github.com/contao/contao-demo/assets/55794780/d1951abb-37b2-47af-966b-3e75f362500f)
![Overflow-Events-Fix](https://github.com/contao/contao-demo/assets/55794780/979aed54-ab83-45ab-9591-3dc232a9351b)
Also the pseudo-element for tables:
![EventsCalendarPseudo-Fix](https://github.com/contao/contao-demo/assets/55794780/3964c9bf-4c2f-41b8-a135-a672efbf036a)

