### PR TITLE
Layout fixing

### DIFF
--- a/files/contaodemo/theme/src/scss/layout/_article.scss
+++ b/files/contaodemo/theme/src/scss/layout/_article.scss
@@ -95,7 +95,7 @@
   // header-slider
   &.header-image {
     @include breakpoint(lg, max) {
-      margin-inline: -$s-grid-outer-gutter--large;
+      padding: 0;
     }
 
     #{$parent}__inner {

--- a/files/contaodemo/theme/src/scss/layout/_article.scss
+++ b/files/contaodemo/theme/src/scss/layout/_article.scss
@@ -1,9 +1,6 @@
 .mod_article {
   $parent: &;
 
-  display: flex;
-  justify-content: center;
-
   &__inner {
     display: grid;
     grid-template-columns: repeat(12, 1fr);


### PR DESCRIPTION
[Can be upstreamed to the 5.x branch]

This PR fixes following issues:

- Horizontal overflow on homepage-slider (header-image-slider) b805558aa5b9c3af582683edcb358a5a9e67f740

> Due to using margin-inline and not resetting the padding, the horizontal axis will be wider than the actual content

![image](https://github.com/contao/contao-demo/assets/55794780/2d13656b-71de-423c-a1b8-338a8c53a828)

- Fixed an issue where "Syndication" and "Backlink" from **mod_article** were not considered at all

> Removed `display: flex` and the horizontal properties from mod_article as they were added for centering *future content* without having any effect and breaking pages that allow syndication (events) and backlinks (most detail pages)

![image](https://github.com/contao/contao-demo/assets/55794780/d763dee6-ec6f-44bd-b2ff-96814e7e1d1a)
