### PR TITLE
Add gitignore to allow app within repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/.gitignore export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Configuration
+/config/parameters.yaml
+/config/parameters.yml
+
+# Composer
+/composer.lock
+/vendor/
+
+# Contao Manager
+/contao-manager/
+
+# Git
+/.git
+
+# IDE
+/.idea
+/.ide
+
+# Generated folders
+/assets/
+/public/
+/system/
+/var/*
+!/var/backups/
+
+# Skip files
+/system/modules/*/.skip
+/.env
+/.env.local

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Configuration
-/config/parameters.yaml
-/config/parameters.yml
+/.env.local
 
 # Composer
 /composer.lock
@@ -8,13 +7,6 @@
 
 # Contao Manager
 /contao-manager/
-
-# Git
-/.git
-
-# IDE
-/.idea
-/.ide
 
 # Generated folders
 /assets/
@@ -25,5 +17,3 @@
 
 # Skip files
 /system/modules/*/.skip
-/.env
-/.env.local

--- a/composer.json
+++ b/composer.json
@@ -46,5 +46,11 @@
         "post-update-cmd": [
             "@php vendor/bin/contao-setup"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true,
+            "contao/manager-plugin": true
+        }
     }
 }


### PR DESCRIPTION
<h3>QoL Developer improvements</h3>


**TL;DR**

> This PR improves QoL for developers working on the contao-demo

___

**Description**

This PR allows installing Contao within the cloned repository by git-ignoring the usual folders and adding the allowed plugins within composer.json. This allows developers to work within the cloned repository and install the demo within it.

I made sure that the var/backups folder is not excluded, so it allows uploading the backups (``contao:backup:restore``)

___

*Edit*
- this change can be upstreamed into the 5.2.* branch (main)