### PR TITLE
Rework form.error

### DIFF
--- a/files/contaodemo/theme/src/scss/components/basic-contents/_form.scss
+++ b/files/contaodemo/theme/src/scss/components/basic-contents/_form.scss
@@ -377,22 +377,21 @@ form {
     @extend .button--lg;
   }
 
-  // error messages
-  .widget.error {
-    position: relative;
-    padding-block-end: 1.875rem;
-  }
-
   p.error {
     @include set-font-size(text--sm);
-
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    z-index: 5;
+    @extend .box--gray-light;
 
     margin: 0;
+    padding: 1rem;
 
+    background: $c-form-field--bg;
     color: $c-form-field--text-error;
+
+    order: 9; // Last order within form-grid
+
+    // Reorder form submit to the end
+    ~ .widget-submit {
+      order: 10
+    }
   }
 }


### PR DESCRIPTION
# Rework form error styles

This PR introduces new styles for forms when an error occured:

- added box styles
- does not use position absolute anymore
- leverage grid properties (using order as every form is a grid in this demo)
- consider modules (login/registration) -> fixes #9 as well

Screenshots:

## Modules
![modules](https://github.com/contao/contao-demo/assets/55794780/f9f516c7-4bd8-4c47-8bda-258d6def1b8b)


## Forms
![form](https://github.com/contao/contao-demo/assets/55794780/66b067eb-5390-4e2f-a536-367d889433e2)
