### PR TITLE
Add `allow-plugins`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,15 @@
         "contao/news-bundle": "4.13.*",
         "contao/newsletter-bundle": "4.13.*"
     },
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "contao-community-alliance/composer-plugin": true,
+            "contao-components/installer": true,
+            "contao/manager-plugin": true,
+            "php-http/discovery": false
+        }
+    },
     "extra": {
         "contao-component-dir": "assets"
     },
@@ -46,14 +55,5 @@
         "post-update-cmd": [
             "@php vendor/bin/contao-setup"
         ]
-    },
-    "config": {
-        "allow-plugins": {
-            "composer/package-versions-deprecated": true,
-            "contao-community-alliance/composer-plugin": true,
-            "contao-components/installer": true,
-            "contao/manager-plugin": true,
-            "php-http/discovery": false
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -46,5 +46,14 @@
         "post-update-cmd": [
             "@php vendor/bin/contao-setup"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "contao-community-alliance/composer-plugin": true,
+            "contao-components/installer": true,
+            "contao/manager-plugin": true,
+            "php-http/discovery": false
+        }
     }
 }


### PR DESCRIPTION
The current `composer.json` is still missing the [`allow-plugins` section of the `contao/managed-edition`](https://github.com/contao/managed-edition/blob/7662f3a20a6366d678afc78613ace16169929535/composer.json#L19-L27) causing prompts when installing via `composer create-project`.