### PR TITLE
A11y | Properly handle checkbox & radio widgets

### DIFF
--- a/files/contaodemo/theme/src/scss/components/basic-contents/_form.scss
+++ b/files/contaodemo/theme/src/scss/components/basic-contents/_form.scss
@@ -188,11 +188,9 @@ form {
   }
 
   // checkbox & radio
-  .checkbox_container,
-  .radio_container {
+  :is(.checkbox_container, .radio_container) {
     position: relative;
   }
-
 
   // input fields
   .text,
@@ -260,9 +258,9 @@ form {
 
   // general checkmark layout
 
-  input:focus-visible + label:before{
-    outline:3px dashed $c-form-field--focus-border;
-    outline-offset:2px
+  input:focus-visible + label:before {
+    outline: 3px dashed $c-form-field--focus-border;
+    outline-offset: 2px;
   }
 
   input.checkbox,

--- a/files/contaodemo/theme/src/scss/components/basic-contents/_form.scss
+++ b/files/contaodemo/theme/src/scss/components/basic-contents/_form.scss
@@ -185,12 +185,12 @@ form {
     &-textarea {
       max-width: 40.5rem;
     }
+  }
 
-    // checkbox & radio
-    .checkbox_container,
-    .radio_container {
-
-    }
+  // checkbox & radio
+  .checkbox_container,
+  .radio_container {
+    position: relative;
   }
 
 
@@ -259,6 +259,12 @@ form {
   }
 
   // general checkmark layout
+
+  input:focus-visible + label:before{
+    outline:3px dashed $c-form-field--focus-border;
+    outline-offset:2px
+  }
+
   input.checkbox,
   input.radio {
 
@@ -278,7 +284,6 @@ form {
       padding:0;
 
       opacity: 0;
-      visibility: hidden;
 
       line-height: 0;
 


### PR DESCRIPTION
## Description

This pull request fixes the issue that checkbox / radio fields are not addressable by `tab` and are hidden from screenreaders due to the `visibility: hidden` attribute

### Fix

This actually removes the visibility attribute, adds a `position: relative` and adds a `focus: visible` so you'll see if you are focusing the attribute:

![image](https://github.com/user-attachments/assets/af855288-4d0a-44cc-97ab-19803d6417ff)
