### PR TITLE
A11y | Main navigation (Part 2)

### DIFF
--- a/files/contaodemo/theme/src/js/a11y-nav.js
+++ b/files/contaodemo/theme/src/js/a11y-nav.js
@@ -56,6 +56,11 @@ class A11yNav {
         this.btn.ariaExpanded = 'false'
     }
 
+    /**
+     * Determines the focus trap targets
+     *
+     * @private
+     */
     _initFocusTrapTargets() {
         const nodes = [this.navigation.parentNode?.querySelector('a[href].logo'), ...this.navigation.querySelectorAll('a[href]:not([disabled]), button:not([disabled])')]
 
@@ -63,7 +68,12 @@ class A11yNav {
         this.lastFocus = nodes[nodes.length - 1] ?? []
     }
 
-    _focusEvent(event) {
+    /**
+     * Handles the focus trap on the open mobile navigation
+     *
+     * @private
+     */
+    _focusTrapEvent(event) {
         if (!(event.key === 'Tab' || event.keyCode === 9))
             return
 
@@ -78,14 +88,19 @@ class A11yNav {
         }
     }
 
+    /**
+     * Adds and removes the focusTrap based on the mobile navigation state
+     *
+     * @private
+     */
     _focusMenu() {
         // consider the navigation state from scripts.js
         const state = document.body.classList.contains('show-nav-mobile')
 
         if (state)
-            document.addEventListener('keydown', this._focusEvent, false)
+            document.addEventListener('keydown', this._focusTrapEvent, false)
         else
-            document.removeEventListener('keydown', this._focusEvent, false)
+            document.removeEventListener('keydown', this._focusTrapEvent, false)
     }
 
     /**
@@ -256,7 +271,7 @@ class A11yNav {
 
     _initMobileToggleEvents() {
         this._initFocusTrapTargets()
-        this._focusEvent = this._focusEvent.bind(this)
+        this._focusTrapEvent = this._focusTrapEvent.bind(this)
 
         this.toggle?.addEventListener('click', () => {
             if (window.innerWidth < this.options.minWidth)

--- a/files/contaodemo/theme/src/js/a11y-nav.js
+++ b/files/contaodemo/theme/src/js/a11y-nav.js
@@ -3,6 +3,7 @@ class A11yNav {
     constructor(options) {
         this.options = this._merge({
             selector: 'header .nav-main',
+            minWidth: 1024,
             classes: {
                 submenuButton: 'btn-toggle-submenu',
                 expand: 'nav-expanded'
@@ -20,8 +21,15 @@ class A11yNav {
             return;
         }
 
-        this.navItems = [];
-        this._init()
+        this.dropdowns = [];
+        this.active = [];
+
+        this._init();
+        this._createSubMenuButton();
+
+        this.dropdowns.forEach(dropdown => {
+            this._initDropdown(dropdown)
+        });
     }
 
     /**
@@ -37,35 +45,7 @@ class A11yNav {
     }
 
     /**
-     * Initializes navigation item and sets aria-attributes if they do not exist
-     *
-     * @private
-     */
-    _initItems() {
-        if (!this.navigation.ariaLabel) {
-            this.navigation.ariaLabel = this.options.ariaLabels.main
-        }
-
-        this.navigation.querySelectorAll('li').forEach(item => {
-            item.role = 'none';
-
-            const navItem = item.firstElementChild;
-
-            if (navItem.classList.contains('active')) {
-                navItem.ariaCurrent = 'page';
-            }
-
-            if (!navItem.ariaLabel && navItem.title) {
-                navItem.ariaLabel = navItem.title;
-                navItem.removeAttribute('title');
-            }
-
-            this.navItems.push(navItem);
-        })
-    }
-
-    /**
-     * Placeholder button that is used to clone for each submenu item
+     * Placeholder button that is cloned for each submenu item
      *
      * @private
      */
@@ -77,16 +57,117 @@ class A11yNav {
     }
 
     /**
-     * Updates the aria labels based on the state and toggles the expand class
+     * Initializes navigation items and sets aria-attributes if they do not exist
      *
      * @private
      */
-    _updateAriaState(btn) {
-        const state = btn.ariaExpanded ?? 'false';
+    _init() {
+        this._createSubMenuButton()
 
-        btn.closest('li.submenu')?.classList.toggle(this.options.classes.expand);
-        btn.ariaLabel = (('false' === state) ? this.options.ariaLabels.collapse : this.options.ariaLabels.expand) + btn.dataset.label;
-        btn.ariaExpanded = ('false' === state) ? 'true' : 'false';
+        if (!this.navigation.ariaLabel) {
+            this.navigation.ariaLabel = this.options.ariaLabels.main
+        }
+
+        this.navigation.querySelectorAll('li').forEach(item => {
+
+            if (item.classList.contains('submenu')) {
+                this.dropdowns.push(item);
+            }
+
+            const navItem = item.firstElementChild;
+
+            if (navItem.classList.contains('active')) {
+                navItem.ariaCurrent = 'page';
+            }
+
+            if (!navItem.ariaLabel && navItem.title) {
+                navItem.ariaLabel = navItem.title;
+                navItem.removeAttribute('title');
+            }
+        })
+
+        // Hide the active navigation on escape
+        document.addEventListener('keyup', (e) => {
+            e.key === 'Escape' && this._hide();
+        })
+    }
+
+    /**
+     * Updates the aria labels and state for the dropdown buttons
+     *
+     * @private
+     */
+    _updateAriaState(dropdown, show) {
+        dropdown.btn.ariaLabel = (show ? this.options.ariaLabels.collapse : this.options.ariaLabels.expand) + dropdown.btn.dataset.label;
+        dropdown.btn.ariaExpanded = show ? 'true' : 'false';
+    }
+
+    /**
+     * Collapses the dropdown
+     *
+     * @private
+     */
+    _collapse(dropdown) {
+        dropdown.classList.remove(this.options.classes.expand);
+        this._updateAriaState(dropdown, false)
+    }
+
+    /**
+     * Handles hiding dropdowns. Adding no parameter will close all
+     *
+     * @private
+     */
+    _hide(dropdown = null) {
+        if (0 === this.active.length) return;
+
+        // Case 1: Leaving the previous dropdown (e.g. focus left)
+        if (this.active.includes(dropdown)) {
+            this._collapse(dropdown);
+            this.active = this.active.filter(node => node !== dropdown);
+        }
+
+        // Case 2: Not contained in the tree at all, remove everything
+        else if (null === dropdown || this.active[0] !== dropdown && !this.active[0].contains(dropdown)) {
+            this.active.forEach(node => this._collapse(node));
+            this.active = [];
+        }
+
+        // Case 3: Down the drain with everything that ain't a parent node :)
+        else {
+            this.active.filter(node => {
+                if (node.contains(dropdown)) {
+                    return true;
+                }
+
+                this._collapse(node);
+                return false;
+            });
+        }
+    }
+
+    /**
+     * Shows the dropdown
+     *
+     * @private
+     */
+    _show(dropdown) {
+        this._hide(dropdown);
+
+        dropdown.classList.add(this.options.classes.expand);
+        this._updateAriaState(dropdown, true);
+
+        if (!this.active.includes(dropdown)) {
+            this.active.push(dropdown);
+        }
+    }
+
+    /**
+     * Updates the dropdown state
+     *
+     * @private
+     */
+    _toggle(dropdown, show) {
+        show ? this._show(dropdown) : this._hide(dropdown);
     }
 
     /**
@@ -94,32 +175,64 @@ class A11yNav {
      *
      * @private
      */
-    _addSubMenuButton(item) {
-        const btn = this.btn.cloneNode();
+    _addSubMenuButton(dropdown) {
+        const item = dropdown.firstElementChild,
+              btn = this.btn.cloneNode();
+
+        dropdown.btn = btn;
 
         btn.dataset.label = item.textContent;
         btn.ariaLabel = this.options.ariaLabels.expand + item.textContent;
 
         btn.addEventListener('click', () => {
-            this._updateAriaState(btn);
+            const show = btn.ariaExpanded === 'false' ?? true;
+            this._toggle(dropdown, show);
         });
 
         item.after(btn);
     }
 
     /**
-     * Initializes the accessibility navigation
+     * Mouse enter event for dropdowns
      *
      * @private
      */
-    _init() {
-        this._initItems();
-        this._createSubMenuButton();
+    _mouseEnter(e, dropdown) {
+        this._toggle(dropdown, true);
+    }
 
-        this.navItems.forEach(item => {
-            if (item.classList.contains('submenu')) {
-                this._addSubMenuButton(item);
-            }
-        });
+    /**
+     * Mouse leave event for dropdowns
+     *
+     * @private
+     */
+    _mouseLeave(e, dropdown) {
+        this._hide(dropdown);
+    }
+
+    /**
+     * Listener for the focusout event when an element loses it's focus, necessary for tab control
+     *
+     * @private
+     */
+    _focusOut(e, dropdown) {
+        if (e.relatedTarget && this.active.length > 0 && !dropdown.contains(e.relatedTarget)) {
+            this._hide(dropdown);
+        }
+    }
+
+    /**
+     * Initializes the dropdown
+     *
+     * @private
+     */
+    _initDropdown(dropdown) {
+        this._addSubMenuButton(dropdown)
+
+        const minWidth = window.innerWidth >= this.options.minWidth;
+
+        dropdown.addEventListener('mouseenter', e => { minWidth && this._mouseEnter(e, dropdown) });
+        dropdown.addEventListener('mouseleave', e => { minWidth && this._mouseLeave(e, dropdown) });
+        dropdown.addEventListener('focusout', e => { minWidth && this._focusOut(e, dropdown) });
     }
 }

--- a/files/contaodemo/theme/src/js/a11y-nav.js
+++ b/files/contaodemo/theme/src/js/a11y-nav.js
@@ -1,8 +1,8 @@
 class A11yNav {
-
     constructor(options) {
         this.options = this._merge({
             selector: 'header .nav-main',
+            toggle: 'header .nav-toggle',
             minWidth: 1024,
             classes: {
                 submenuButton: 'btn-toggle-submenu',
@@ -13,23 +13,23 @@ class A11yNav {
                 'expand': 'Expand menu: ',
                 'collapse': 'Collapse menu: '
             }
-        }, options || {});
+        }, options || {})
 
-        this.navigation = document.querySelector(this.options.selector);
+        this.navigation = document.querySelector(this.options.selector)
+        this.toggle = document.querySelector(this.options.toggle)
 
         if (!this.navigation) {
-            return;
+            return
         }
 
-        this.dropdowns = [];
-        this.active = [];
+        this.dropdowns = []
+        this.active = []
 
-        this._init();
-        this._createSubMenuButton();
+        this._init()
 
         this.dropdowns.forEach(dropdown => {
             this._initDropdown(dropdown)
-        });
+        })
     }
 
     /**
@@ -41,7 +41,7 @@ class A11yNav {
         return [...new Set([...Object.keys(a), ...Object.keys(b)])].reduce((result, key) => ({
             ...result,
             [key]: "object" === typeof (a[key]) ? Object.assign({}, a[key], b[key]) : !b[key] ? a[key] : b[key]
-        }), {});
+        }), {})
     }
 
     /**
@@ -50,10 +50,42 @@ class A11yNav {
      * @private
      */
     _createSubMenuButton() {
-        this.btn = document.createElement('button');
-        this.btn.classList.add(this.options.classes.submenuButton);
-        this.btn.ariaHasPopup = 'true';
-        this.btn.ariaExpanded = 'false';
+        this.btn = document.createElement('button')
+        this.btn.classList.add(this.options.classes.submenuButton)
+        this.btn.ariaHasPopup = 'true'
+        this.btn.ariaExpanded = 'false'
+    }
+
+    _initFocusTrapTargets() {
+        const nodes = [this.navigation.parentNode?.querySelector('a[href].logo'), ...this.navigation.querySelectorAll('a[href]:not([disabled]), button:not([disabled])')]
+
+        this.firstFocus = nodes[0] ?? []
+        this.lastFocus = nodes[nodes.length - 1] ?? []
+    }
+
+    _focusEvent(event) {
+        if (!(event.key === 'Tab' || event.keyCode === 9))
+            return
+
+        if (document.activeElement === this.lastFocus && !event.shiftKey) {
+            event.preventDefault()
+            this.firstFocus?.focus()
+        }
+
+        if (document.activeElement === this.firstFocus && event.shiftKey) {
+            event.preventDefault()
+            this.lastFocus?.focus()
+        }
+    }
+
+    _focusMenu() {
+        // consider the navigation state from scripts.js
+        const state = document.body.classList.contains('show-nav-mobile')
+
+        if (state)
+            document.addEventListener('keydown', this._focusEvent, false)
+        else
+            document.removeEventListener('keydown', this._focusEvent, false)
     }
 
     /**
@@ -63,6 +95,7 @@ class A11yNav {
      */
     _init() {
         this._createSubMenuButton()
+        this._initMobileToggleEvents()
 
         if (!this.navigation.ariaLabel) {
             this.navigation.ariaLabel = this.options.ariaLabels.main
@@ -71,24 +104,24 @@ class A11yNav {
         this.navigation.querySelectorAll('li').forEach(item => {
 
             if (item.classList.contains('submenu')) {
-                this.dropdowns.push(item);
+                this.dropdowns.push(item)
             }
 
-            const navItem = item.firstElementChild;
+            const navItem = item.firstElementChild
 
             if (navItem.classList.contains('active')) {
-                navItem.ariaCurrent = 'page';
+                navItem.ariaCurrent = 'page'
             }
 
             if (!navItem.ariaLabel && navItem.title) {
-                navItem.ariaLabel = navItem.title;
-                navItem.removeAttribute('title');
+                navItem.ariaLabel = navItem.title
+                navItem.removeAttribute('title')
             }
         })
 
         // Hide the active navigation on escape
         document.addEventListener('keyup', (e) => {
-            e.key === 'Escape' && this._hide();
+            e.key === 'Escape' && this._hideDropdown()
         })
     }
 
@@ -98,8 +131,8 @@ class A11yNav {
      * @private
      */
     _updateAriaState(dropdown, show) {
-        dropdown.btn.ariaLabel = (show ? this.options.ariaLabels.collapse : this.options.ariaLabels.expand) + dropdown.btn.dataset.label;
-        dropdown.btn.ariaExpanded = show ? 'true' : 'false';
+        dropdown.btn.ariaLabel = (show ? this.options.ariaLabels.collapse : this.options.ariaLabels.expand) + dropdown.btn.dataset.label
+        dropdown.btn.ariaExpanded = show ? 'true' : 'false'
     }
 
     /**
@@ -107,8 +140,8 @@ class A11yNav {
      *
      * @private
      */
-    _collapse(dropdown) {
-        dropdown.classList.remove(this.options.classes.expand);
+    _collapseSubmenu(dropdown) {
+        dropdown.classList.remove(this.options.classes.expand)
         this._updateAriaState(dropdown, false)
     }
 
@@ -117,31 +150,31 @@ class A11yNav {
      *
      * @private
      */
-    _hide(dropdown = null) {
-        if (0 === this.active.length) return;
+    _hideDropdown(dropdown = null) {
+        if (0 === this.active.length) return
 
         // Case 1: Leaving the previous dropdown (e.g. focus left)
         if (this.active.includes(dropdown)) {
-            this._collapse(dropdown);
-            this.active = this.active.filter(node => node !== dropdown);
+            this._collapseSubmenu(dropdown)
+            this.active = this.active.filter(node => node !== dropdown)
         }
 
         // Case 2: Not contained in the tree at all, remove everything
         else if (null === dropdown || this.active[0] !== dropdown && !this.active[0].contains(dropdown)) {
-            this.active.forEach(node => this._collapse(node));
-            this.active = [];
+            this.active.forEach(node => this._collapseSubmenu(node))
+            this.active = []
         }
 
         // Case 3: Down the drain with everything that ain't a parent node :)
         else {
             this.active.filter(node => {
                 if (node.contains(dropdown)) {
-                    return true;
+                    return true
                 }
 
-                this._collapse(node);
-                return false;
-            });
+                this._collapseSubmenu(node)
+                return false
+            })
         }
     }
 
@@ -150,14 +183,14 @@ class A11yNav {
      *
      * @private
      */
-    _show(dropdown) {
-        this._hide(dropdown);
+    _showDropdown(dropdown) {
+        this._hideDropdown(dropdown)
 
-        dropdown.classList.add(this.options.classes.expand);
-        this._updateAriaState(dropdown, true);
+        dropdown.classList.add(this.options.classes.expand)
+        this._updateAriaState(dropdown, true)
 
         if (!this.active.includes(dropdown)) {
-            this.active.push(dropdown);
+            this.active.push(dropdown)
         }
     }
 
@@ -166,8 +199,8 @@ class A11yNav {
      *
      * @private
      */
-    _toggle(dropdown, show) {
-        show ? this._show(dropdown) : this._hide(dropdown);
+    _toggleDropdownState(dropdown, show) {
+        show ? this._showDropdown(dropdown) : this._hideDropdown(dropdown)
     }
 
     /**
@@ -177,19 +210,19 @@ class A11yNav {
      */
     _addSubMenuButton(dropdown) {
         const item = dropdown.firstElementChild,
-              btn = this.btn.cloneNode();
+              btn = this.btn.cloneNode()
 
-        dropdown.btn = btn;
+        dropdown.btn = btn
 
-        btn.dataset.label = item.textContent;
-        btn.ariaLabel = this.options.ariaLabels.expand + item.textContent;
+        btn.dataset.label = item.textContent
+        btn.ariaLabel = this.options.ariaLabels.expand + item.textContent
 
         btn.addEventListener('click', () => {
-            const show = btn.ariaExpanded === 'false' ?? true;
-            this._toggle(dropdown, show);
-        });
+            const show = btn.ariaExpanded === 'false' ?? true
+            this._toggleDropdownState(dropdown, show)
+        })
 
-        item.after(btn);
+        item.after(btn)
     }
 
     /**
@@ -198,7 +231,7 @@ class A11yNav {
      * @private
      */
     _mouseEnter(e, dropdown) {
-        this._toggle(dropdown, true);
+        this._toggleDropdownState(dropdown, true)
     }
 
     /**
@@ -207,7 +240,7 @@ class A11yNav {
      * @private
      */
     _mouseLeave(e, dropdown) {
-        this._hide(dropdown);
+        this._hideDropdown(dropdown)
     }
 
     /**
@@ -217,8 +250,18 @@ class A11yNav {
      */
     _focusOut(e, dropdown) {
         if (e.relatedTarget && this.active.length > 0 && !dropdown.contains(e.relatedTarget)) {
-            this._hide(dropdown);
+            this._hideDropdown(dropdown)
         }
+    }
+
+    _initMobileToggleEvents() {
+        this._initFocusTrapTargets()
+        this._focusEvent = this._focusEvent.bind(this)
+
+        this.toggle?.addEventListener('click', () => {
+            if (window.innerWidth < this.options.minWidth)
+                this._focusMenu()
+        })
     }
 
     /**
@@ -229,10 +272,10 @@ class A11yNav {
     _initDropdown(dropdown) {
         this._addSubMenuButton(dropdown)
 
-        const minWidth = window.innerWidth >= this.options.minWidth;
+        const minWidth = window.innerWidth >= this.options.minWidth
 
-        dropdown.addEventListener('mouseenter', e => { minWidth && this._mouseEnter(e, dropdown) });
-        dropdown.addEventListener('mouseleave', e => { minWidth && this._mouseLeave(e, dropdown) });
-        dropdown.addEventListener('focusout', e => { minWidth && this._focusOut(e, dropdown) });
+        dropdown.addEventListener('mouseenter', e => { minWidth && this._mouseEnter(e, dropdown) })
+        dropdown.addEventListener('mouseleave', e => { minWidth && this._mouseLeave(e, dropdown) })
+        dropdown.addEventListener('focusout', e => { minWidth && this._focusOut(e, dropdown) })
     }
 }

--- a/files/contaodemo/theme/src/js/scripts.js
+++ b/files/contaodemo/theme/src/js/scripts.js
@@ -7,36 +7,20 @@ const showNavMobile = 'show-nav-mobile';
 const isActive = 'is-active';
 const preventBodyScrolling = "prevent-scrolling";
 
-if (toggleNavMain) {
-  toggleNavMain.addEventListener('click', navStatus);
+function toggleNavigationState(open) {
+    if (open) {
+        document.body.classList.add(showNavMobile, preventBodyScrolling);
+        navMobile.setAttribute('style', 'top:' + header.offsetHeight + 'px;');
+    } else {
+        document.body.classList.remove(showNavMobile, preventBodyScrolling);
+    }
+
+    toggleNavMain.classList.toggle(isActive, open);
+    toggleNavMain.ariaExpanded = open ? 'true' : 'false';
+
+    navMobile.classList.toggle(isActive, open);
 }
-
-function navStatus() {
-
-  if (document.body.classList.contains(showNavMobile)) {
-    navClose();
-  } else {
-    navOpen();
-  }
-}
-
-function navClose() {
-  document.body.classList.remove(showNavMobile, preventBodyScrolling);
-  toggleNavMain.classList.remove(isActive);
-  toggleNavMain.ariaExpanded = 'false';
-  navMobile.classList.remove(isActive);
-}
-
-function navOpen() {
-  document.body.classList.add(showNavMobile, preventBodyScrolling);
-  toggleNavMain.classList.add(isActive);
-  toggleNavMain.ariaExpanded = 'true';
-  navMobile.classList.add(isActive);
-
-  let headerHeight = header.offsetHeight;
-  navMobile.setAttribute('style', 'top:' + headerHeight + 'px;');
-}
-
+toggleNavMain?.addEventListener('click', () => toggleNavigationState(!document.body.classList.contains(showNavMobile)));
 
 // insert th text in td as data-attr
 document.addEventListener('DOMContentLoaded', function () {

--- a/files/contaodemo/theme/src/scss/components/navigation/_nav-main.scss
+++ b/files/contaodemo/theme/src/scss/components/navigation/_nav-main.scss
@@ -40,8 +40,14 @@ $s-underline-size: .125rem;
         display: flex;
       }
 
-      .btn-toggle-submenu:after {
+      > .btn-toggle-submenu:after {
         height: 2px;
+      }
+
+      > .level_3 {
+        top: -50%;
+        left: 100%;
+        min-width: 200px;
       }
     }
   }
@@ -50,14 +56,14 @@ $s-underline-size: .125rem;
     gap: 0 $header--item-inline-gap;
     justify-content: flex-end;
     align-items: center;
-  }
 
-  .level_2 {
-    display: none;
-    flex-direction: column;
+    ul {
+      display: none;
+      flex-direction: column;
 
-    :is(a, strong) {
-      @include set-font-size(text--md);
+      :is(a, strong) {
+        @include set-font-size(text--md);
+      }
     }
   }
 }
@@ -232,6 +238,24 @@ $s-underline-size: .125rem;
       display: flex;
       flex-wrap: wrap;
       width: revert;
+
+      ul {
+        position: absolute;
+        padding: 15px 0;
+        min-width: 270px;
+        background: #fff;
+        box-shadow: 1px 2px 15px rgba(0, 0, 0, .1);
+        gap: 1rem;
+        z-index: 1;
+
+        li {
+          padding: 0 15px;
+        }
+
+        .btn-toggle-submenu {
+          right: 15px;
+        }
+      }
     }
 
     li {
@@ -239,28 +263,27 @@ $s-underline-size: .125rem;
       &.submenu {
         position: relative;
         padding-right: 18px;
-
-        &:hover {
-
-          > ul {
-            display: flex;
-          }
-
-          .btn-toggle-submenu:after {
-            height: 2px;
-          }
-        }
       }
     }
+  }
+}
 
-    .level_2 {
-      position: absolute;
-      padding: 15px 10px;
-      min-width: 270px;
-      background: #fff;
-      box-shadow: 1px 2px 15px rgba(0, 0, 0, .1);
-      gap: 1rem;
-      z-index: 1;
+@media (forced-colors) {
+  .btn-toggle-submenu:before,
+  .btn-toggle-submenu:after {
+    border: 1px solid currentColor;
+  }
+}
+
+@include breakpoint(#{$bp--mobile}) {
+
+  @media (forced-colors) {
+
+    .nav-main {
+
+      .level_2 {
+        border: 1px solid currentColor;
+      }
     }
   }
 }

--- a/files/contaodemo/theme/src/scss/components/navigation/_nav-toggle.scss
+++ b/files/contaodemo/theme/src/scss/components/navigation/_nav-toggle.scss
@@ -133,3 +133,34 @@ $s-toggle--line-gap: .375rem;
     cursor: pointer;
   }
 }
+
+@media (forced-colors) {
+
+  .nav-toggle {
+
+    &__icon {
+      color: currentColor;
+    }
+
+    .icon-line {
+
+      &,
+      &:before,
+      &:after {
+        height: 0;
+        border: 1px transparent solid;
+      }
+    }
+
+    &.is-active {
+
+      .icon-line {
+        border: 0 none;
+
+        &:after {
+          bottom: -1px;
+        }
+      }
+    }
+  }
+}

--- a/files/contaodemo/theme/src/scss/vendor/_normalizer.scss
+++ b/files/contaodemo/theme/src/scss/vendor/_normalizer.scss
@@ -209,13 +209,6 @@ button::-moz-focus-inner,
  * Restore the focus styles unset by the previous rule.
  */
 
-button:-moz-focusring,
-[type="button"]:-moz-focusring,
-[type="reset"]:-moz-focusring,
-[type="submit"]:-moz-focusring {
-   outline: 1px dotted ButtonText;
-}
-
 /**
  * Correct the padding in Firefox.
  */


### PR DESCRIPTION
Followup of #53 

### Description

* Improve the accessibility-navigation JavaScript 832b2f308aab26f1cb8a01e0b050562286cb9d16

  * close on lost focus (either new focus via hover / active element on focus-tab)
  * handle the aria states for each item and close them accordingly
  * handle the proper events
  * Remove the previously added `aria-role: none` from list elements
  * #58 - Sub-navigation should close on ESC or when leaving the sub-navigation -> Close and handle all previously open dropdowns when pressing ESC

* Handle infinite navigation levels within the main-navigation ddfc2c28f5373c3709f7ccdd7835062544d1aa9d
  * This one adds the same handling for navigations past level_2 in case people would activate them. This has been added to properly implement the accessibility-navigation JavaScript due to the need of handling multiple levels.

* Implements high contrast mode for the navigation
  * #58 - Fix icons in high-contrast mode -> The expand icons + main toggle were reworked in 55a5a77dba49bd224ebe5390eecd347f5a8369c7 and 832b2f308aab26f1cb8a01e0b050562286cb9d16
      <img src="https://github.com/user-attachments/assets/02e68cf7-1745-4fcd-bd3e-9493530051b7" width="300">
    
* Consider focus for all buttons on MacOS 011f21c12a14005d28af02926fb9811a2c6e820e
  * This one actually does not make sense if we want to be accessible since it's a pure design normalizer that would just remove it completely...

### Context

Please mind that using `:hover` for any navigation dropdown that can not be closed by a mechanism is not accessible based on:
https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus

> Dismissible
A [mechanism](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus#dfn-mechanism) is available to dismiss the additional content without moving pointer hover or keyboard focus, unless the additional content communicates an [input error](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus#dfn-input-error) or does not obscure or replace other content;

Aka - Dismissable via ESC https://bitvtest.de/pruefschritt/bitv-20-web/bitv-20-web-9-1-4-13-eingeblendete-inhalte-bedienbar